### PR TITLE
updated to use ~/.arbor

### DIFF
--- a/arbor/cli.py
+++ b/arbor/cli.py
@@ -30,7 +30,7 @@ def create_app(arbor_config_path: str):
     """Create and configure the Arbor API application
 
     Args:
-        storage_path (str): Path to store models and uploaded training files
+        arbor_config_path (str): Path to config file 
 
     Returns:
         FastAPI: Configured FastAPI application
@@ -102,10 +102,12 @@ def stop_server(server):
 @cli.command()
 @click.option("--host", default="0.0.0.0", help="Host to bind to")
 @click.option("--port", default=7453, help="Port to bind to")
-@click.option("--arbor-config", required=True, help="Path to the Arbor config file")
+@click.option("--arbor-config", required=False, help="Path to the Arbor config file")
 def serve(host, port, arbor_config):
     """Start the Arbor API server"""
-    app = create_app(arbor_config)
+    config_path = arbor_config if arbor_config else Settings.find_config_path()
+    create_app(config_path)
+        
     uvicorn.run(app, host=host, port=port)
 
 

--- a/arbor/server/core/config.py
+++ b/arbor/server/core/config.py
@@ -21,7 +21,6 @@ class ArborConfig(BaseModel):
 
 class Settings(BaseModel):
 
-    # STORAGE_PATH: str = "./storage"
     STORAGE_PATH: str = str(Path.home() / ".arbor" / "storage")
     INACTIVITY_TIMEOUT: int = 30  # 5 seconds
     arbor_config: ArborConfig
@@ -35,41 +34,34 @@ class Settings(BaseModel):
 
     def _init_arbor_directories(self):
         arbor_root = Path.home() / ".arbor"
-        config_dir = arbor_root / "config"
         storage_dir = Path(self.STORAGE_PATH)
         
         arbor_root.mkdir(exist_ok=True)
-        config_dir.mkdir(exist_ok=True)
         storage_dir.mkdir(exist_ok=True)
         (storage_dir / "logs").mkdir(exist_ok=True)
         (storage_dir / "models").mkdir(exist_ok=True)
         (storage_dir / "uploads").mkdir(exist_ok=True)
 
     @classmethod
-    def find_config_path(cls) -> Optional[str]:
-        """ Search 1st for: ~/.arbor/config/default.yaml 2nd: ./arbor.yaml (backward compatibility)"""
+    def use_default_config(cls) -> Optional[str]:
+        """ Search for: ~/.arbor/config.yaml, else return None"""
 
-        # Check ~/.arbor/config
-        arbor_config = Path.home() / ".arbor" / "config" / "default.yaml"
+        # Check ~/.arbor/config.yaml
+        arbor_config = Path.home() / ".arbor" / "config.yaml"
         if arbor_config.exists(): 
             return str(arbor_config)
-        
-        # Fall back to local dir
-        local_config = Path("./arbor.yaml")
-        if local_config.exists(): 
-            return str(local_config)
-        
+    
         return None
 
     @classmethod
     def load_from_yaml(cls, yaml_path: str) -> "Settings":
-        # If yaml file is not provided, try to use ~/.arbor/config/default.yaml or ./arbor.yaml
+        # If yaml file is not provided, try to use ~/.arbor/config.yaml 
         if not yaml_path:
-            yaml_path = cls.find_config_path()
+            yaml_path = cls.use_default_config()
         
         if not yaml_path:
             raise ValueError(
-                "No config file found. Please create ~/.arbor/config/default.yaml or "
+                "No config file found. Please create ~/.arbor/config.yaml or "
                 "provide a config file path with --arbor-config"
             )
             

--- a/arbor/server/core/config_manager.py
+++ b/arbor/server/core/config_manager.py
@@ -1,0 +1,105 @@
+import os
+import yaml
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+
+from arbor.server.core.config import Settings
+
+
+class ConfigManager:
+    def __init__(self):
+        self._init_arbor_directories()
+    
+    
+    def _init_arbor_directories(self):
+        arbor_root = Path.home() / ".arbor"
+        config_dir = arbor_root / "config"
+        storage_dir = Path(self.STORAGE_PATH)
+        
+        arbor_root.mkdir(exist_ok=True)
+        config_dir.mkdir(exist_ok=True)
+        storage_dir.mkdir(exist_ok=True)
+        (storage_dir / "logs").mkdir(exist_ok=True)
+        (storage_dir / "models").mkdir(exist_ok=True)
+        (storage_dir / "uploads").mkdir(exist_ok=True)
+    
+    
+    @staticmethod
+    def get_default_config_path() -> Path:
+        return str(Path.home() / ".arbor" / "config" / "default.yaml")
+
+    @staticmethod
+    def get_config_template() -> Dict:
+        return {
+            "inference": {
+                "gpu_ids": "0"
+            },
+            "training": {
+                "gpu_ids": "1, 2"
+            }
+        }
+
+
+    @classmethod
+    def update_config(cls, inference_gpus: Optional[str] = None, training_gpus: Optional[str] = None, config_path: Optional[str] = None) -> str:
+        """ Update existing config or create new one. """
+        if config_path is None:
+            config_path = Settings.find_config_path()
+            if config_path is None:
+                config_path = str(cls.get_default_config_path())
+        
+        
+        config_file = Path(config_path)
+        
+        # Load existing config or use template
+        if config_file.exists():
+            with open(config_file, 'r') as f:
+                config = yaml.safe_load(f) or {}
+        else:
+            config = cls.get_config_template()
+        
+        # Update values given
+        if inference_gpus is not None:
+            if "inference" not in config: config["inference"] = {}
+            config["inference"]["gpu_ids"] = inference_gpus
+        
+        if training_gpus is not None:
+            if "training" not in config: config["training"] = {}
+            config["training"]["gpu_ids"] = training_gpus
+        
+        temp_path = config_file.with_suffix('.tmp')
+        try:
+            with open(temp_path, 'w') as f:
+                yaml.dump(config, f, default_flow_style=False)
+            temp_path.rename(config_file)
+        except Exception:
+            if temp_path.exists():
+                temp_path.unlink()
+            raise
+            
+        
+        return str(config_file)
+
+    @classmethod
+    def validate_config_file(cls, config_path: str) -> Tuple[bool, str]:
+        """ Validate a config file """
+        try:
+            if not Path(config_path).exists():
+                return False, f"Config file does not exist: {config_path}"
+            
+            # If we do have a config file, try to see if it will load
+            Settings.load_from_yaml(config_path)
+            return True, "Config is valid"
+            
+        except Exception as e:
+            return False, f"Invalid config: {e}"
+
+    @classmethod
+    def get_config_contents(cls, config_path: str) -> Tuple[bool, str]:
+        try: 
+            with open(config_path, 'r') as f:
+                config_content = f.read()
+            return True, config_content
+        except Exception as e:
+            return False, str(e)


### PR DESCRIPTION
## Overview:

1. Centralized user config and storage at `~/.arbor` 
2. arbor/server/core/config.py: functions _init_arbor_directories (automatically creates this if doesn't exist along w/ config and storage) and  find_config_file (searches for config file within `.~/arbor/config` or `.` dir)
3. Can use "arbor.cli serve" without the specifying config path

##  Issues:
in cli.py, start_server has parameter storage_path, which is passed into create_app. However, create_app expects a config file path. I did not change this as I was unsure of ./storage's role. Seems like it is used for testing in test_cli.py, however it seems outdated now.

##  Future work:
Create unit tests for this (which is where start_server is used)
