### PR TITLE
add yaml arg parsing for context length

### DIFF
--- a/arbor/server/core/config.py
+++ b/arbor/server/core/config.py
@@ -9,6 +9,7 @@ class Config(BaseModel):
 
     # Basic settings
     storage_path: str = str(Path.home() / ".arbor" / "storage")
+    max_context_length: Optional[int] = None
 
     # Training settings
     accelerate_config: Optional[str] = None

--- a/arbor/server/services/jobs/grpo_job.py
+++ b/arbor/server/services/jobs/grpo_job.py
@@ -152,8 +152,15 @@ class GRPOJob(Job):
             f"Allocated {total_gpus} GPUs for GRPO job {self.id}: inference={inference_gpus}, training={training_gpus}"
         )
 
+        max_context_length_from_request = arbor_train_kwargs.get("max_context_length")
+        effective_max_context_length = (
+            max_context_length_from_request
+            if max_context_length_from_request is not None
+            else self.config.max_context_length
+        )
+
         inference_launch_config = InferenceLaunchConfig(
-            max_context_length=arbor_train_kwargs.get("max_context_length", None),
+            max_context_length=effective_max_context_length,
             gpu_ids=inference_gpus,
             is_grpo=True,
             grpo_job_id=self.id,

--- a/arbor/server/services/managers/inference_manager.py
+++ b/arbor/server/services/managers/inference_manager.py
@@ -29,7 +29,11 @@ class InferenceManager(BaseManager):
                     f"Allocated GPUs {allocated_gpus} for inference job {inference_job.id}"
                 )
 
-                inference_launch_config = InferenceLaunchConfig(gpu_ids=allocated_gpus)
+                inference_launch_config = InferenceLaunchConfig(
+                    gpu_ids=allocated_gpus,
+                    max_context_length=self.config.max_context_length,
+                )
+                
                 inference_job.launch(model, inference_launch_config)
                 # This needs to have a unique id or something, not be referenced by model
                 self.inference_jobs[model] = inference_job


### PR DESCRIPTION
I was running into an issue where the LM response was being cut off prematurely 

I found out the max_tokens defined for the dspy.LM was not being passed to the vllm instance started by arbor

So I decided to add it as an option to the arbor config.yaml 

```yaml
max_context_length: 32768  # Ensure this matches your model's capabilities
inference:
  gpu_ids: [0]  # Adjust based on your available GPUs
training:
  gpu_ids: [1]
```

Things I think that may or may not be necessary

- made the grpo_job max_context_length fall back to this as a parameter if it's not passed in via the API
- didn't touch the SFT/DPO fine tunes to use this as a fallback (this might be helpful?)

This PR is just a suggestion and a temporary fix, there is probably a better way to do this 


