### PR TITLE
Rename `TrainerControlClient._handle` to avoid collision with Python 3.13+

### DIFF
--- a/arbor/server/services/comms/control_client.py
+++ b/arbor/server/services/comms/control_client.py
@@ -47,7 +47,7 @@ class TrainerControlClient(threading.Thread):
                 try:
                     message = socket.recv_json()
                     try:
-                        response = self._handle(message)
+                        response = self._handle_message(message)
                     except Exception as handler_exc:
                         response = {"ok": False, "error": str(handler_exc)}
                     socket.send_json(response)
@@ -75,7 +75,7 @@ class TrainerControlClient(threading.Thread):
             except Exception:
                 pass
 
-    def _handle(self, message: Dict[str, Any]) -> Dict[str, Any]:
+    def _handle_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
         cmd = message.get("cmd")
         requester = self.trainer.async_requester
 


### PR DESCRIPTION
Background: In Python 3.13, `threading.Thread` has a new private attributed named `_handle`. It leads to the following error response on every calls:

```json
{"ok":false,"error":"TypeError: '_thread._ThreadHandle' object is not callable"}
```

Rename the custom `_handle` function to `_handle_message` to fix Python 3.13+ compatibility.