### PR TITLE
Eliminate hardcoded `python` to ensure always starting with current Python

### DIFF
--- a/arbor/server/utils/process_runner.py
+++ b/arbor/server/utils/process_runner.py
@@ -221,7 +221,7 @@ class AccelerateProcessRunner(ProcessRunner):
             log_callback: Function to call with each log line
         """
         command = [
-            "python",
+            sys.executable,
             "-m",
             "accelerate.commands.launch",
             "--num_processes",


### PR DESCRIPTION
This also aligned the Python used to start `accelerate` with starting vLLM, and fixed the problem where users of `uv`, `py`, `python3`, ... may not have `python` in their paths.