### PR TITLE
Trigger trainer checkpoint saves via control flag

### DIFF
--- a/arbor/server/api/models/schemas.py
+++ b/arbor/server/api/models/schemas.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Generic, List, Literal, Optional, TypeVar
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 # Generic type for list items
 T = TypeVar("T")
@@ -205,9 +205,11 @@ class GRPOStatus(StrictBaseModel):
     job_id: str
     status: Optional[str] = None
     current_model: str
-    checkpoints: dict[str, str]
+    checkpoints: dict[str, Optional[str]] = Field(default_factory=dict)
     last_checkpoint: Optional[str] = None
-    pending_batch_ids: List[int] = []
+    pending_batch_ids: List[int] = Field(default_factory=list)
+    checkpoint_metadata: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    checkpoint_errors: dict[str, str] = Field(default_factory=dict)
 
 
 class LoRAConfigRequest(StrictBaseModel):
@@ -277,6 +279,7 @@ class GRPOStepRequest(GRPOBaseRequest):
 
 class GRPOCheckpointRequest(GRPOBaseRequest):
     checkpoint_name: str
+    metadata: Optional[dict[str, Any]] = None
 
 
 class GRPOTerminateRequest(GRPOBaseRequest):

--- a/arbor/server/services/comms/control_server.py
+++ b/arbor/server/services/comms/control_server.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Mapping, Optional
 import threading
 import time
+from typing import Any, Dict, Mapping, Optional
 
 import zmq
 
@@ -115,8 +115,13 @@ class TrainerControlServer:
             )
         return resp
 
-    def request_checkpoint(self, checkpoint_name: str) -> Dict[str, Any]:
-        resp = self._request({"cmd": "checkpoint", "checkpoint_name": checkpoint_name})
+    def request_checkpoint(
+        self, checkpoint_name: str, metadata: Mapping[str, Any] | None = None
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"cmd": "checkpoint", "checkpoint_name": checkpoint_name}
+        if metadata is not None:
+            payload["metadata"] = metadata
+        resp = self._request(payload)
         if not resp.get("ok", False):
             raise RuntimeError(
                 f"Error requesting checkpoint: {resp.get('error', 'Unknown error')}"


### PR DESCRIPTION
## Summary
- refactor the GRPO job event loop to route checkpoint status handling through a dedicated helper
- queue trainer checkpoint requests, flip the Trainer control flag to save asynchronously, and record results in the `_save_checkpoint` override
- surface active checkpoint requests in trainer status snapshots and harden metadata/error bookkeeping

## Testing
- `uv run ruff format arbor/server/services/jobs/grpo_job.py arbor/server/services/scripts/arbor_grpo_trainer.py` *(fails: offline environment cannot reach pypi.org)*

------
https://chatgpt.com/codex/tasks/task_e_68f270a498a0832489ca09c80dc25a69