### PR TITLE
Keep GRPO inference logs in parent job

### DIFF
--- a/arbor/server/services/jobs/inference_launch_config.py
+++ b/arbor/server/services/jobs/inference_launch_config.py
@@ -8,3 +8,4 @@ class InferenceLaunchConfig:
     gpu_ids: Optional[list[int]] = None
     is_grpo: Optional[bool] = False
     grpo_job_id: Optional[str] = None
+    log_file_path: Optional[str] = None

--- a/arbor/server/services/managers/inference_manager.py
+++ b/arbor/server/services/managers/inference_manager.py
@@ -52,7 +52,8 @@ class InferenceManager(BaseManager):
         launch_config: InferenceLaunchConfig,
         trainer_controller: TrainerControlServer,
     ):
-        inference_job = InferenceJob(self.config)
+        is_grpo_sub_job = bool(launch_config.is_grpo and launch_config.grpo_job_id)
+        inference_job = InferenceJob(self.config, is_grpo_sub_job=is_grpo_sub_job)
 
         # Use provided GPU IDs or allocate through GPU manager
         if launch_config.gpu_ids is None:


### PR DESCRIPTION
## Summary
- ensure GRPO inference jobs write their logs into the parent GRPO log directory by passing the path through the launch config
- skip standalone directory setup for GRPO inference jobs and allow them to promote to standalone logging once training ends
- instantiate inference jobs with awareness of GRPO launches and carry the log file path in the launch configuration

## Testing
- uv run pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68f6a6fed074832484a14cc70827bd8e