### PR TITLE
Fix GRPO inference assertion guard

### DIFF
--- a/arbor/server/services/jobs/inference_job.py
+++ b/arbor/server/services/jobs/inference_job.py
@@ -79,9 +79,11 @@ class InferenceJob(Job):
         launch_config = launch_config or self.launch_config
 
         # If this is a GRPO inference job, inherit the parent job's ID and don't create separate directories
-        if launch_config.is_grpo and launch_config.grpo_job_id:
+        self._is_grpo_sub_job = bool(
+            launch_config.is_grpo and launch_config.grpo_job_id
+        )
+        if self._is_grpo_sub_job:
             self.id = f"{launch_config.grpo_job_id}-inference"
-            self._is_grpo_sub_job = True
             assert trainer_controller is not None, (
                 "Trainer controller is required for GRPO inference jobs"
             )


### PR DESCRIPTION
## Summary
- determine the GRPO sub-job flag from the current launch configuration before launching
- only require a trainer controller when launching GRPO sub-jobs so standalone inference keeps working

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f6b67fa2f883248173f18b30691db8