### PR TITLE
fix: Resolve broken hover-nlp/hover dataset

### DIFF
--- a/examples/multihop_dev.py
+++ b/examples/multihop_dev.py
@@ -41,7 +41,7 @@ import random
 from dspy.datasets import DataLoader
 
 kwargs = dict(fields=("claim", "supporting_facts", "hpqa_id", "num_hops"), input_keys=("claim",))
-hover = DataLoader().from_huggingface(dataset_name="hover-nlp/hover", split="train", trust_remote_code=True, **kwargs)
+hover = DataLoader().from_huggingface(dataset_name="vincentkoc/hover-parquet", split="train", trust_remote_code=True, **kwargs)
 
 hpqa_ids = set()
 hover = [


### PR DESCRIPTION
Huggingface no longer allows untrusted scripts to pull data from huggingface, fixing this source dataset with a fork that has been corrected `vincentkoc/hover-parquet` see https://huggingface.co/datasets/vincentkoc/hover-parquet