### PR TITLE
[bug] Fix mixed_precision value formatting in YAML config

### DIFF
--- a/configs/deepspeed_config.yaml
+++ b/configs/deepspeed_config.yaml
@@ -15,7 +15,7 @@ distributed_type: DEEPSPEED
 downcast_bf16: 'no'
 machine_rank: 0
 main_training_function: main
-mixed_precision: no
+mixed_precision: 'no'
 num_machines: 1
 # num_processes: 4 //infer from command line
 rdzv_backend: static


### PR DESCRIPTION
The GRPO training was failing with the following error:
```
  File "....../python3.11/site-packages/accelerate/utils/launch.py", line 505, in prepare_deepspeed_cmd_env
    mixed_precision = PrecisionType(args.mixed_precision.lower())
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  AttributeError: 'bool' object has no attribute 'lower'
```

In YAML, unquoted `no` is parsed as boolean `False` instead of the string `'no'`. This PR fixes the issue by adding quotes.