### PR TITLE
Fix incorrect GRPOGroup type hints

### DIFF
--- a/arbor/integrations/dspy/grpo_optimizer.py
+++ b/arbor/integrations/dspy/grpo_optimizer.py
@@ -19,7 +19,12 @@ from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.xml_adapter import XMLAdapter
 from dspy.clients.lm import LM
-from dspy.clients.utils_finetune import GRPOChatData, GRPOGroup, GRPOStatus, TrainDataFormat
+from dspy.clients.utils_finetune import (
+    GRPOChatData,
+    GRPOGroup,
+    GRPOStatus,
+    TrainDataFormat,
+)
 from dspy.dsp.utils.settings import settings
 from dspy.evaluate.evaluate import Evaluate
 from dspy.primitives.example import Example

--- a/arbor/integrations/dspy/grpo_optimizer.py
+++ b/arbor/integrations/dspy/grpo_optimizer.py
@@ -19,7 +19,7 @@ from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.xml_adapter import XMLAdapter
 from dspy.clients.lm import LM
-from dspy.clients.utils_finetune import GRPOGroup, GRPOStatus, TrainDataFormat
+from dspy.clients.utils_finetune import GRPOChatData, GRPOGroup, GRPOStatus, TrainDataFormat
 from dspy.dsp.utils.settings import settings
 from dspy.evaluate.evaluate import Evaluate
 from dspy.primitives.example import Example
@@ -573,7 +573,7 @@ class ArborGRPO(FinetuneTeleprompter):
             logger.info(
                 "Preparing the training data batch from bootstrapped examples for GRPO..."
             )
-            train_batch_per_predictor: list[list[GRPOGroup]] = [
+            train_batch_per_predictor: list[list[list[GRPOChatData]]] = [
                 [] for _ in range(num_student_predictors)
             ]
             for pred_id in range(num_student_predictors):
@@ -653,7 +653,7 @@ class ArborGRPO(FinetuneTeleprompter):
                         ]
                     )
 
-                    example_training_data: list[GRPOGroup] = [
+                    example_training_data: list[list[GRPOChatData]] = [
                         [] for _ in range(max_len)
                     ]
 
@@ -759,10 +759,10 @@ class ArborGRPO(FinetuneTeleprompter):
                         )
 
             logger.info("Invoking GRPO training step...")
-            all_train_data: list[GRPOGroup] = list(
+            all_train_data: list[list[GRPOChatData]] = list(
                 chain.from_iterable(train_batch_per_predictor)
             )
-            train_data: list[GRPOGroup] = all_train_data
+            train_data: list[list[GRPOChatData]] = all_train_data
             for group in train_data:
                 if len(group) != self.num_rollouts_per_grpo_step:
                     while len(group) < self.num_rollouts_per_grpo_step:


### PR DESCRIPTION
The objects labelled as `GRPOGroup` are actually lists of `GRPOChatData`.

For example, one of the mislabelled variables is defined as:
```python
example_training_data: list[GRPOGroup] = [
    [] for _ in range(max_len)
]
```
which is a list of lists, but GRPOGroup is a dict. Furthermore, the following lines suggest the inner lists contain dictionaries matching GRPOChatData:
```python
example_training_data[group_idx].append(
    {
        "messages": inp_messages,
        "completion": {
            "role": "assistant",
            "content": trace_instance[
                2
            ].completion_text,
        },
        "reward": float(score),
    }
)
```
Thus changing GRPOGroup to list[GRPOChatData] is warranted.

Relevant definitions from [dspy/clients/utils_finetune.py](https://github.com/stanfordnlp/dspy/blob/c21f77bc5a3b5a78e2edd55aa28bb5fdf0aad2c8/dspy/clients/utils_finetune.py#L37):

```python
class GRPOChatData(TypedDict):
    messages: list[Message]
    completion: MessageAssistant
    reward: float

class GRPOGroup(TypedDict):
    batch_id: int | None
    group: list[GRPOChatData]
```